### PR TITLE
Try arping as last resort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Added warning about Python 2 compatibility being dropped in 1.0.0
 * Officially support Python 3.8
 * Documented a known issue with looking up IP of a local interface on Linux/WSL (See the "Known Issues" section in the README)
+* Added lookup using `arping` as last resort
 
 ### Dev
 * Standardized formatting on [Black](https://github.com/psf/black)

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ to ask questions or discuss the project (Handle: @KnownError).
 * @fortunate-man - Awesome usage videos
 * @martmists - legacy Python compatibility improvements
 * @hargoniX - scripts and specfiles for RPM packaging
+* Ville Skyttä (@scop) - arping lookup support
 
 ## Sources
 Many of the methods used to acquire an address and the core logic framework

--- a/getmac/getmac.py
+++ b/getmac/getmac.py
@@ -388,6 +388,14 @@ def _read_arp_file(host):
     return None
 
 
+def _arping(host):
+    # type: (str) -> Optional[str]
+    return _search(
+        r" from %s \[(%s)\]" % (re.escape(host), MAC_RE_COLON),
+        _popen("arping", "-f -c 1 %s" % host),
+    )
+
+
 def _read_file(filepath):
     # type: (str) -> Optional[str]
     try:
@@ -525,6 +533,9 @@ def _hunt_for_mac(to_find, type_of_thing, net_ok=True):
             ),
             _uuid_ip,
         ]
+        # Add methods that make network requests
+        if net_ok and type_of_thing != IP6:
+            methods.append(_arping)
     else:
         log.critical("Reached end of _hunt_for_mac() if-else chain!")
         return None

--- a/tests/samples/ubuntu_18.10/arping.out
+++ b/tests/samples/ubuntu_18.10/arping.out
@@ -1,0 +1,4 @@
+ARPING 192.168.16.254 from 192.168.16.42 ens33
+Unicast reply from 192.168.16.254 [00:50:56:E8:32:3C]  7.521ms
+Sent 1 probes (1 broadcast(s))
+Received 1 response(s)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -53,6 +53,12 @@ def test_hunt_linux_default_iface(benchmark, mocker, get_sample):
     assert benchmark(getmac._hunt_linux_default_iface) == "ens33"
 
 
+def test_arping(benchmark, mocker, get_sample):
+    content = get_sample("ubuntu_18.10/arping.out")
+    mocker.patch("getmac.getmac._popen", return_value=content)
+    assert benchmark(getmac._arping, host="192.168.16.254") == "00:50:56:E8:32:3C"
+
+
 def test_ubuntu_1804_interface(benchmark, mocker, get_sample):
     mocker.patch("getmac.getmac.WINDOWS", False)
     mocker.patch("getmac.getmac.DARWIN", False)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Code changes:

* [x] Did you format your code with Black? 
    * [x] `black getmac tests`
* [ ] Are the linting checks passing?
    * [ ] `tox -e check` -- no, but they weren't passing before this change either:
```
check run-test: commands[3] | flake8 getmac tests setup.py
getmac/getmac.py:1:1: T499 Success: no issues found in 1 source file
# -*- coding: utf-8 -*-
^
ERROR: InvocationError for command [...]/getmac/.tox/check/bin/flake8 getmac tests setup.py (exited with code 1)
```
* [x] Do all tests pass locally?
    * [x] `tox`
* [x] Have you updated the [CHANGELOG](CHANGELOG.md) with a summary of your change?
* [x] Did you add your name to the contributors list in the [README](README.md)?

### Summary of changes:
When other things have yielded no results, try arping. Depending on system, it may require an interface to be specified and fail without one, but would improve things where it doesn't.

