### PR TITLE
0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 **Announcement**: Compatibility with Python versions older than 3.7 (2.7, 3.4, 3.5, and 3.6) is deprecated and will be removed in getmac 1.0.0. If you are stuck on an unsupported Python, consider loosely pinning the version of this package in your dependency list, e.g. `getmac<1.0.0` or `getmac~=0.9.0`.
 
+## 0.9.4 (06/01/2023)
+
+### Added
+* Support BusyBox's ``arping``
+
+### Changed
+* Improve how ARP is handled. If ``ArpFile`` method succeeds, use it instead of ``ArpingHost`` (this should fix [#86](https://github.com/GhostofGoes/getmac/issues/86), for realsies this time).
+* Speed up the first call to ``ArpingHost``
+* Fix FORCE_METHOD not being respected for IPv4 macs
+
 ## 0.9.3 (03/16/2023)
 
 ### Changed

--- a/getmac/getmac.py
+++ b/getmac/getmac.py
@@ -1352,6 +1352,7 @@ def get_method_by_name(method_name):
 
 
 def get_instance_from_cache(method_type, method_name):
+    # type: (str, str) -> Optional[Method]
     """
     Get the class for a named Method from the caches.
 
@@ -1363,7 +1364,6 @@ def get_instance_from_cache(method_type, method_name):
         method_type: method type to initialize the cache for.
             Allowed values are:  ``ip4`` | ``ip6`` | ``iface`` | ``default_iface``
     """
-    # type: (str, str) -> Optional[Method]
 
     if str(METHOD_CACHE[method_type]) == method_name:
         return METHOD_CACHE[method_type]
@@ -1702,7 +1702,7 @@ def get_by_method(method_type, arg="", network_request=True):
     return result
 
 
-def get_mac_address(
+def get_mac_address(  # noqa: C901
     interface=None, ip=None, ip6=None, hostname=None, network_request=True
 ):
     # type: (Optional[str], Optional[str], Optional[str], Optional[str], bool) -> Optional[str]

--- a/getmac/getmac.py
+++ b/getmac/getmac.py
@@ -56,7 +56,7 @@ log = logging.getLogger("getmac")  # type: logging.Logger
 if not log.handlers:
     log.addHandler(logging.NullHandler())
 
-__version__ = "0.9.3"
+__version__ = "0.9.4"
 
 PY2 = sys.version_info[0] == 2  # type: bool
 

--- a/getmac/getmac.py
+++ b/getmac/getmac.py
@@ -1334,6 +1334,30 @@ def get_method_by_name(method_name):
     return None
 
 
+def get_instance_from_cache(method_type, method_name):
+    """
+    Get the class for a named Method from the caches.
+
+    METHOD_CACHE is checked first, and if that fails,
+    then any entries in FALLBACK_CACHE are checked.
+    If both fail, None is returned.
+
+    Args:
+        method_type: method type to initialize the cache for.
+            Allowed values are:  ``ip4`` | ``ip6`` | ``iface`` | ``default_iface``
+    """
+    # type: (str, str) -> Optional[Method]
+
+    if str(METHOD_CACHE[method_type]) == method_name:
+        return METHOD_CACHE[method_type]
+
+    for f_meth in FALLBACK_CACHE[method_type]:
+        if str(f_meth) == method_name:
+            return f_meth
+
+    return None
+
+
 def _swap_method_fallback(method_type, swap_with):
     # type: (str, str) -> bool
     if str(METHOD_CACHE[method_type]) == swap_with:

--- a/getmac/getmac.py
+++ b/getmac/getmac.py
@@ -1273,8 +1273,8 @@ class DefaultIfaceFreeBsd(Method):
 METHODS = [
     # NOTE: CtypesHost is faster than ArpExe because of sub-process startup times :)
     CtypesHost,
-    ArpingHost,
     ArpFile,
+    ArpingHost,
     SysIfaceFile,
     FcntlIface,
     UuidLanscan,

--- a/tests/samples/WSL2_kali_2023.1/busbox_arping_--ridic.out
+++ b/tests/samples/WSL2_kali_2023.1/busbox_arping_--ridic.out
@@ -1,0 +1,18 @@
+arping: unrecognized option '--ridic'
+BusyBox v1.35.0 (Debian 1:1.35.0-4+b3) multi-call binary.
+
+Usage: arping [-fqbDUA] [-c CNT] [-w TIMEOUT] [-I IFACE] [-s SRC_IP] DST_IP
+
+Send ARP requests/replies
+
+        -f              Quit on first ARP reply
+        -q              Quiet
+        -b              Keep broadcasting, don't go unicast
+        -D              Exit with 1 if DST_IP replies
+        -U              Unsolicited ARP mode, update your neighbors
+        -A              ARP answer mode, update your neighbors
+        -c N            Stop after sending N ARP requests
+        -w TIMEOUT      Seconds to wait for ARP reply
+        -I IFACE        Interface to use (default eth0)
+        -s SRC_IP       Sender IP address
+        DST_IP          Target IP address

--- a/tests/samples/WSL2_kali_2023.1/busybox_arping_-f_-c_1_172-29-16-1.out
+++ b/tests/samples/WSL2_kali_2023.1/busybox_arping_-f_-c_1_172-29-16-1.out
@@ -1,0 +1,4 @@
+ARPING 172.29.16.1 from 172.29.17.66 eth0
+Unicast reply from 172.29.16.1 [00:15:5d:20:f2:73] 0.175ms
+Sent 1 probe(s) (0 broadcast(s))
+Received 1 response(s) (0 request(s), 0 broadcast(s))

--- a/tests/samples/WSL2_kali_2023.1/habets_arping_-f_-c_1_172-29-16-1.out
+++ b/tests/samples/WSL2_kali_2023.1/habets_arping_-f_-c_1_172-29-16-1.out
@@ -1,0 +1,7 @@
+arping: invalid option -- 'f'
+ARPing 2.23, by Thomas Habets <thomas@habets.se>
+usage: arping [ -0aAbdDeFpPqrRuUvzZ ] [ -w <sec> ] [ -W <sec> ] [ -S <host/ip> ]
+              [ -T <host/ip ] [ -s <MAC> ] [ -t <MAC> ] [ -c <count> ]
+              [ -C <count> ] [ -i <interface> ] [ -m <type> ] [ -g <group> ]
+              [ -V <vlan> ] [ -Q <priority> ] <host/ip/MAC | -B>
+For complete usage info, use --help or check the manpage.

--- a/tests/samples/WSL2_kali_2023.1/iputils_arping_--help.out
+++ b/tests/samples/WSL2_kali_2023.1/iputils_arping_--help.out
@@ -1,0 +1,21 @@
+arping: invalid option -- '-'
+
+Usage:
+  arping [options] <destination>
+
+Options:
+  -f            quit on first reply
+  -q            be quiet
+  -b            keep on broadcasting, do not unicast
+  -D            duplicate address detection mode
+  -U            unsolicited ARP mode, update your neighbours
+  -A            ARP answer mode, update your neighbours
+  -V            print version and exit
+  -c <count>    how many packets to send
+  -w <timeout>  how long to wait for a reply
+  -i <interval> set interval between packets (default: 1 second)
+  -I <device>   which ethernet device to use
+  -s <source>   source ip address
+  <destination> dns name or ip address
+
+For more details see arping(8).

--- a/tests/test_getmac.py
+++ b/tests/test_getmac.py
@@ -109,6 +109,18 @@ def test_get_method_by_name():
     assert getmac.get_method_by_name("getmacexe") == getmac.GetmacExe
 
 
+def test_get_instance_from_cache(mocker):
+    with pytest.raises(KeyError):
+        getmac.get_instance_from_cache("", "")
+
+    inst = getmac.ArpFile()
+    mocker.patch("getmac.getmac.METHOD_CACHE", {"ip4": inst})
+    assert getmac.get_instance_from_cache("ip4", "ArpFile") is inst
+
+    mocker.patch("getmac.getmac.METHOD_CACHE", {"ip4": None})
+    assert getmac.get_instance_from_cache("ip4", "ArpFile") is None
+
+
 def test_swap_method_fallback(mocker):
     mocker.patch("getmac.getmac.METHOD_CACHE", {"ip4": getmac.ArpExe()})
     mocker.patch("getmac.getmac.FALLBACK_CACHE", {"ip4": [getmac.CtypesHost()]})

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -132,24 +132,33 @@ def test_ifconfigwithifacearg_bad_exits(mocker):
 
 def test_arping_host_habets(benchmark, mocker, get_sample):
     content = get_sample("ubuntu_18.04/arping-habets.out")
-    cpe = CalledProcessError(cmd="", returncode=1)
-    mocker.patch("getmac.getmac._popen", side_effect=cpe)
+    mocker.patch("getmac.getmac._popen", return_value=content)
 
     ap = getmac.ArpingHost()
+    ap._is_iputils = False
     ap.get("192.168.16.254")
-    mocker.patch("getmac.getmac._popen", return_value=content)
+
     assert "00:50:56:e8:32:3c" == benchmark(ap.get, arg="192.168.16.254")
 
 
 def test_arping_host_iputils(benchmark, mocker, get_sample):
     content = get_sample("ubuntu_18.04/arping-iputils.out")
-    cpe = CalledProcessError(cmd="", returncode=2)
-    mocker.patch("getmac.getmac._popen", side_effect=cpe)
+    mocker.patch("getmac.getmac._popen", return_value=content)
 
     ap = getmac.ArpingHost()
     ap.get("192.168.16.254")
-    mocker.patch("getmac.getmac._popen", return_value=content)
+
     assert "00:50:56:E8:32:3C" == benchmark(ap.get, arg="192.168.16.254")
+
+
+def test_arping_host_busybox(benchmark, mocker, get_sample):
+    content = get_sample("WSL2_kali_2023.1/busybox_arping_-f_-c_1_172-29-16-1.out")
+    mocker.patch("getmac.getmac._popen", return_value=content)
+
+    ap = getmac.ArpingHost()
+    ap.get("172.29.16.1")
+
+    assert "00:15:5d:20:f2:73" == benchmark(ap.get, arg="172.29.16.1")
 
 
 def test_windows_10_iface_getmac_exe(benchmark, mocker, get_sample):


### PR DESCRIPTION
### Added
* Support BusyBox's ``arping``

### Changed
* Improve how ARP is handled. If ``ArpFile`` method succeeds, use it instead of ``ArpingHost`` (this should fix [#86](https://github.com/GhostofGoes/getmac/issues/86), for realsies this time).
* Speed up the first call to ``ArpingHost``
* Fix FORCE_METHOD not being respected for IPv4 macs

This should properly fix #86