### PR TITLE
Fix for macOS arp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 **Announcement**: Compatibility with Python versions older than 3.7 (2.7, 3.4, 3.5, and 3.6) is deprecated and will be removed in getmac 1.0.0. If you are stuck on an unsupported Python, consider loosely pinning the version of this package in your dependency list, e.g. `getmac<1.0.0` or `getmac~=0.9.0`.
 
+## 0.9.5 ()
+
+### Changed
+* Fixed macOS arp when MAC has one character sections in specific cases (Fixes issue #92)
+
 ## 0.9.4 (06/01/2023)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ The [Python Discord server](https://discord.gg/python) is a good place to ask qu
 - Ville Skyttä (@scop) - arping lookup support
 - Tomasz Duda (@tomaszduda23) - support for docker in network bridge mode
 - Steven Looman (@StevenLooman) - Windows 11 testing
+- Reimund Renner (@raymanP) - macOS fixes
 
 ## Sources
 Many of the methods used to acquire an address and the core logic framework are attributed to the CPython project's UUID implementation.

--- a/getmac/getmac.py
+++ b/getmac/getmac.py
@@ -520,7 +520,6 @@ class ArpVariousArgs(Method):
         return _search(r"\(" + escaped + self._good_regex, command_output)
 
 
-
 class ArpExe(Method):
     """
     Query the Windows ARP table using ``arp.exe`` to find the MAC address of a remote host.

--- a/getmac/getmac.py
+++ b/getmac/getmac.py
@@ -467,7 +467,7 @@ class ArpVariousArgs(Method):
     )
     _args_tested = False  # type: bool
     _good_pair = ()  # type: Union[Tuple, Tuple[str, bool]]
-    _good_regex = ""  # type: str
+    _good_regex = _regex_darwin if DARWIN else _regex_std  # type: str
 
     def test(self):  # type: () -> bool
         return check_command("arp")
@@ -517,22 +517,8 @@ class ArpVariousArgs(Method):
             command_output = _popen("arp", " ".join(cmd_args))
 
         escaped = re.escape(arg)
-        if self._good_regex:
-            return _search(r"\(" + escaped + self._good_regex, command_output)
+        return _search(r"\(" + escaped + self._good_regex, command_output)
 
-        # try linux regex first
-        # try darwin regex next
-        #   if a regex succeeds the first time, cache the successful regex
-        #   otherwise, don't bother, since it's a miss anyway
-        for regex in (self._regex_std, self._regex_darwin):
-            # NOTE: Darwin regex will return MACs without leading zeroes,
-            # e.g. "58:6d:8f:7:c9:94" instead of "58:6d:8f:07:c9:94"
-            found = _search(r"\(" + escaped + regex, command_output)
-            if found:
-                self._good_regex = regex
-                return found
-
-        return None
 
 
 class ArpExe(Method):


### PR DESCRIPTION
Tested and working on macOS.

### All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Code changes:

- [x] Did you format your code with Black? 
    - `black getmac tests`
- [x] Are the linting checks passing?
    - `tox -e check`
- [x] Do all tests pass locally?
    - `tox`
- [x] Have you updated the [CHANGELOG](CHANGELOG.md) with a summary of your change?
- [x] Did you add your name to the contributors list in the [README](README.md)?

### Summary of changes:
- selects arp regexp by global `DARWIN` variable instead of testing variants (_regex_std, _regex_darwin), which was not fail proof
